### PR TITLE
Aggiunto uno script che permette di creare componenti

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ index.test.jsx
 cypress.config.js
 jest.config.js
 next-i18next.config
+create-component.js

--- a/_test_/index.test.jsx
+++ b/_test_/index.test.jsx
@@ -10,6 +10,6 @@ describe('Home', () => {
     //The render method is used to render (or mount) the Home component within a virtual testing environment.
     render(<Home />);
     //The debug method is used to display in the terminal the tree of DOM nodes that corresponds to the selected element, in this case the level 1 heading.
-    screen.debug(screen.getByRole('heading', { level: 1 }));
+    expect(screen.get('heading', { level: 1 })).toBeInTheDocument();
   });
 });

--- a/common/utils/createAxiosClient.ts
+++ b/common/utils/createAxiosClient.ts
@@ -2,8 +2,7 @@
 
 import Axios from 'axios';
 
-export const AxiosClient = () => {
-  return Axios.create({
+export const AxiosClient = () =>
+  Axios.create({
     headers: { Authorization: 'Bearer ----', apiKey: '' },
   });
-};

--- a/create-component.js
+++ b/create-component.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/** @format */
+
+const fs = require('fs');
+const path = require('path');
+const inquirer = require('inquirer');
+
+const COMPONENT_TYPES = {
+  'components.ui': 'UI component',
+  'components-shared': 'Shared component',
+  utils: 'Utility function',
+  hooks: 'Hook function',
+};
+
+function createComponent() {
+  inquirer
+    .prompt([
+      {
+        type: 'input',
+        name: 'componentName',
+        message: 'Enter component name:',
+        validate: function (input) {
+          if (/^([A-Za-z\-\_\d])+$/.test(input)) return true;
+          else return 'Component name may only include letters, numbers, underscores and hashes.';
+        },
+      },
+      {
+        type: 'list',
+        name: 'componentType',
+        message: 'Select component type:',
+        choices: Object.values(COMPONENT_TYPES),
+      },
+      {
+        type: 'confirm',
+        name: 'hasTest',
+        message: 'Would you like to add this component to unit test?',
+      },
+    ])
+    .then(({ componentName, componentType, hasTest }) => {
+      const componentTypeKey = Object.keys(COMPONENT_TYPES).find(key => COMPONENT_TYPES[key] === componentType);
+      const dirPath = path.join(
+        process.cwd(),
+        componentTypeKey === 'components.ui'
+          ? 'common/components.ui'
+          : componentTypeKey === 'components-shared'
+          ? 'common/components-shared'
+          : componentTypeKey === 'utils'
+          ? 'common/utils'
+          : 'common/hooks',
+      );
+      const componentFilePath = path.join(dirPath, `${componentName}.tsx`);
+
+      if (fs.existsSync(componentFilePath)) {
+        console.error(`Component "${componentName}" already exists!`);
+        process.exit(1);
+      }
+
+      fs.mkdirSync(dirPath, { recursive: true });
+
+      const componentNameUpper = componentName.charAt(0).toUpperCase() + componentName.slice(1);
+
+      let componentContent = '';
+
+      if (componentTypeKey === 'components.ui') {
+        componentContent = `
+import { memo } from 'react';
+
+import styled from '@emotion/styled';
+
+      const Styled${componentNameUpper}Container = styled.div\({
+      /* Add your styles here */
+      \});
+            
+      interface Props {
+      label?: string;
+      /* Add your props here */
+      }
+            
+      export const ${componentNameUpper} = memo(({ label }: Props) =>  <Styled${componentNameUpper}Container>{label}</Styled${componentNameUpper}Container>
+        );
+        `;
+      } else if (componentTypeKey === 'components-shared') {
+        componentContent = `
+        import { memo } from 'react';
+
+        import styled from '@emotion/styled';
+        import { useTranslation } from 'next-i18next';
+
+              const Styled${componentNameUpper}Container = styled.div\({
+              /* Add your styles here */
+              \});
+                    
+              interface Props {
+              label?: string;
+              /* Add your props here */
+              }
+                    
+              export const ${componentNameUpper} = memo(({ label }: Props) => {
+                const { t } = useTranslation('common');
+                return (
+                  <Styled${componentNameUpper}Container>
+                  {t(label)}
+                  </Styled${componentNameUpper}Container>
+                );
+                },
+                );
+                `;
+      } else if (componentTypeKey === 'utility') {
+        componentContent = `export const ${componentNameUpper} = () => {
+          // Add your utility function here
+        };
+        `;
+      } else if (componentTypeKey === 'hook') {
+        componentContent = `export const ${componentNameUpper} = () => {
+                  // Add your hook function here
+                  const count = 0;
+                  return {
+                    // Add your return here
+                    count
+                  }
+                };
+                `;
+      }
+
+      fs.writeFileSync(componentFilePath, componentContent);
+
+      console.log(`Component "${componentName}" created successfully as "${componentType}" component!`);
+
+      if (hasTest) {
+        componentContent = `
+/** @format */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ${componentNameUpper} } from '../common/${componentTypeKey}/${componentName}';
+        
+        describe('${componentNameUpper}', () => {
+          test('renders without errors', () => {
+            const { getByText } = render(<${componentNameUpper} label="Click Me" />);
+            const componentElement = getByText('Click Me');
+            expect(componentElement).toBeInTheDocument();
+          });
+        });
+            
+`;
+        const componentFilePath = path.join('./_test_', `${componentName}.test.jsx`);
+        fs.writeFileSync(componentFilePath, componentContent);
+      }
+    });
+}
+
+createComponent();

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 /** @type {import('jest').Config} */
 const customJestConfig = {
-  // Add more setup options before each test is run
-  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+/** @format */
+
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "cypress": "cypress open",
     "postbuild": "next-sitemap",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "create-component": "node create-component.js"
   },
   "dependencies": {
     "@docusaurus/core": "^2.4.0",
@@ -27,6 +28,7 @@
     "@storybook/testing-library": "^0.0.13",
     "axios": "^1.3.4",
     "i18next": "^22.4.13",
+    "inquirer": "^8.0.0",
     "next": "13.2.4",
     "next-i18next": "^13.2.2",
     "next-seo": "^5.15.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -70,7 +70,6 @@ export default function Home() {
           }}
         />
       </Head>
-      <h1>{t('title')}</h1>
       <Link href={`/${t('developers')}`} locale={i18n?.language}>
         {t('developers')}
       </Link>


### PR DESCRIPTION
Refs #33

## Description

Aggiunto uno script che permette di creare diversi componenti (components-ui/components-shared/utility/hooks) molto basilari inserendo il nome e selezionando il tipo di componente, la directory dove verrà creato il componente dipende dal tipo di componente che viene selezionato


Aggiunta opzione che permette. di selezionare un componente generico o un componente pre esistente, nel caso della selezione di un componente pre esistente viene selezionato il componente che si desidera creare e viene creato nella cartella components-ui

## Questions/comments to the reviewer

_Please indicate if there are any things to be aware of or things you need input on_

## Change Type - select the relevant change type:

- [ ] 🐛 Bug fix (non-critical change that fixes a problem)
- [x] 🆕 New feature (non-critical change that adds functionality)
- [ ] 💄 Adjustment (visual adjustment or simple logical adjustments)
- [ ] 💥 Breaking change (fix or features that may cause existing ones to not work as expected)

## Tested on - select relevant device type:

- [x] Chrome
- [ ] Firefox
- [ ] Brave
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Mozilla
- [ ] Explorer

## How to test - include a list of things to test

_Include links or other ways to easily locate test data_

### Screenshots, video recordings 📸 👇
